### PR TITLE
Fix favicon in projects index

### DIFF
--- a/projects/index.shtml
+++ b/projects/index.shtml
@@ -12,7 +12,7 @@
 	<meta name="description" content="" />
 	<meta name="keywords" content="" />
 	<link rel="stylesheet" href="/assets/css/main.css" />
-	<link rel="icon" href="images/vrs_logo_white_icon.png"/>
+	<link rel="icon" href="/images/vrs_logo_white_icon.png"/>
 </head>
 
 <body class="is-preload">


### PR DESCRIPTION
Just a tiny missing slash broke the favicon link on the [projects index page](http://robotics.ece.pdx.edu/projects/).