### PR TITLE
removed overflow from main.css on the vrs logo.

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2488,7 +2488,6 @@ body {
 
 #vrs-text {
   white-space: nowrap;
-  overflow-x: scroll;
 }
 
 /* Heading */


### PR DESCRIPTION
It's not needed since "white-spce: nowrap;" prevents the
text from showing up on multiple lines.